### PR TITLE
Don't look for keyword at start of line

### DIFF
--- a/postfix/clamav.pm
+++ b/postfix/clamav.pm
@@ -43,17 +43,17 @@ sub analyse {
 	# clam found something
 	++$$stats{'clamav:found'};
 	if ( $line =~ /(trojan)/i
-		or $line =~ /^Heuristics\.(phishing)\./i
+		or $line =~ /Heuristics\.(phishing)\./i
 		or $line =~ /(phishing)\./i
-		or $line =~ /^(fraud)\./i
-		or $line =~ /^(scam)\./i
-		or $line =~ /^(exploit)\./i
-		or $line =~ /^(virus)\./i
-		or $line =~ /^(worm)\./i
-		or $line =~ /^(malware)\./i
-		or $line =~ /^(spam)\./i
-		or $line =~ /^(archive)\./i
-		or $line =~ /^(suspect)\./i ) {
+		or $line =~ /(fraud)\./i
+		or $line =~ /(scam)\./i
+		or $line =~ /(exploit)\./i
+		or $line =~ /(virus)\./i
+		or $line =~ /(worm)\./i
+		or $line =~ /(malware)\./i
+		or $line =~ /(spam)\./i
+		or $line =~ /(archive)\./i
+		or $line =~ /(suspect)\./i ) {
 		# we know about this - count it
 		++$$stats{"clamav:found:".lc ( $1 )};
 	} else {


### PR DESCRIPTION
The log message
```
Feb  5 23:55:06 hades clamav-milter[1387]: Message 6B1792407C from <emailcheck-robot@ct.de> to <jan@faked.org> with subject 'c t-Emailcheck: Netsky.P (lbebasb)' message-id '<E1caVi6-0002rA-4R.octo04@web.heise.de>' date 'Sun, 05 Feb 2017 23:55:06 +0100' infected by Html.Exploit.IFrame-17
```
was detected as "Other", even though it contained "Exploit". With this change it is detected correctly.